### PR TITLE
Support for routes_{env}.{ext}

### DIFF
--- a/src/UpKernel.php
+++ b/src/UpKernel.php
@@ -70,6 +70,6 @@ abstract class UpKernel extends Kernel
         $routes->import($this->getConfigurationDir() . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($this->getConfigurationDir() . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($this->getConfigurationDir() . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($this->getConfigurationDir() . '/{routes}_' . $this->environment . self::CONFIG_EXTS, 'glob');
+        $routes->import($this->getConfigurationDir() . '/{routes}_' . $this->environment . self::CONFIG_EXTS, '/', 'glob');
     }
 }

--- a/src/UpKernel.php
+++ b/src/UpKernel.php
@@ -70,5 +70,6 @@ abstract class UpKernel extends Kernel
         $routes->import($this->getConfigurationDir() . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($this->getConfigurationDir() . '/{routes}/' . $this->environment . '/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($this->getConfigurationDir() . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($this->getConfigurationDir() . '/{routes}_' . $this->environment . self::CONFIG_EXTS, 'glob');
     }
 }


### PR DESCRIPTION
With this change it's possible to keep all configuration files in one directory. For example:

- config/
  - bundles.php
  - config.yml
  - config_dev.yml
  - routes.yml
  - routes_dev.yml
  - services.yml
  - services_dev.yml